### PR TITLE
Preserve custom short link casing

### DIFF
--- a/app/api/shortlinks/route.js
+++ b/app/api/shortlinks/route.js
@@ -18,7 +18,7 @@ function toSlugValidationMessage(errorCode) {
     case SHORTLINK_SLUG_ERROR_CODES.TOO_LONG:
       return "Custom back-half must be at most 64 characters";
     case SHORTLINK_SLUG_ERROR_CODES.INVALID_FORMAT:
-      return "Custom back-half can only contain lowercase letters, numbers, '-' and '_'";
+      return "Custom back-half can only contain letters, numbers, '-' and '_'";
     case SHORTLINK_SLUG_ERROR_CODES.RESERVED:
       return "Custom back-half is reserved";
     default:

--- a/app/dashboard/forms/page.jsx
+++ b/app/dashboard/forms/page.jsx
@@ -37,7 +37,7 @@ function getShortLinkValidationMessage(errorCode) {
     case SHORTLINK_SLUG_ERROR_CODES.TOO_LONG:
       return "Slug maksimal 64 karakter.";
     case SHORTLINK_SLUG_ERROR_CODES.INVALID_FORMAT:
-      return "Slug hanya boleh huruf kecil, angka, '-' dan '_'.";
+      return "Slug hanya boleh huruf, angka, '-' dan '_'.";
     case SHORTLINK_SLUG_ERROR_CODES.RESERVED:
       return "Slug ini reserved, pakai slug lain.";
     default:

--- a/app/login/page.jsx
+++ b/app/login/page.jsx
@@ -99,10 +99,9 @@ export default function LoginPage() {
         </div>
       </div>
       <footer className="text-xs text-gray-500 font-body text-center py-4 mb-4">
-        © 2025 Technic 8EH Radio ITB. All rights reserved.
+        © {new Date().getFullYear()} Technic 8EH Radio ITB. All rights reserved.
       </footer>
     </div>
   );
 
 }
-

--- a/lib/shortlinks/slug.js
+++ b/lib/shortlinks/slug.js
@@ -1,7 +1,7 @@
 export const SHORTLINK_HOST = "8eh.link";
 export const SHORTLINK_MIN_LENGTH = 3;
 export const SHORTLINK_MAX_LENGTH = 64;
-export const SHORTLINK_SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+export const SHORTLINK_SLUG_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 
 export const RESERVED_SHORTLINK_SLUGS = new Set([
   "api",
@@ -33,16 +33,20 @@ export const SHORTLINK_SLUG_ERROR_CODES = {
   RESERVED: "reserved",
 };
 
+export function isReservedShortLinkSlug(slug) {
+  return RESERVED_SHORTLINK_SLUGS.has(String(slug || "").toLowerCase());
+}
+
 export function normalizeShortLinkSlug(value) {
   if (typeof value !== "string") return "";
 
-  let normalized = value.trim().toLowerCase();
-  normalized = normalized.replace(/^https?:\/\/(www\.)?8eh\.link\/?/, "");
-  normalized = normalized.replace(/^8eh\.link\/?/, "");
+  let normalized = value.trim();
+  normalized = normalized.replace(/^https?:\/\/(www\.)?8eh\.link\/?/i, "");
+  normalized = normalized.replace(/^8eh\.link\/?/i, "");
   normalized = normalized.replace(/^\/+/, "");
   normalized = normalized.replace(/[?#].*$/, "");
   normalized = normalized.replace(/\s+/g, "-");
-  normalized = normalized.replace(/[^a-z0-9_-]/g, "");
+  normalized = normalized.replace(/[^A-Za-z0-9_-]/g, "");
   normalized = normalized.replace(/-{2,}/g, "-");
   normalized = normalized.replace(/^-+|-+$/g, "");
 
@@ -78,7 +82,7 @@ export function validateShortLinkSlug(slug) {
     };
   }
 
-  if (RESERVED_SHORTLINK_SLUGS.has(slug)) {
+  if (isReservedShortLinkSlug(slug)) {
     return {
       valid: false,
       code: SHORTLINK_SLUG_ERROR_CODES.RESERVED,

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,28 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-
-const RESERVED = [
-  "",
-  "api",
-  "dashboard",
-  "login",
-  "not-found",
-  "password",
-  "blog",
-  "about-us",
-  "agency",
-  "media-partner",
-  "podcast",
-  "programs",
-  "faq",
-  "proxy-audio",
-  "_next",
-  "favicon.ico",
-  "contributors",
-  "events",
-  "forms",
-  "profile",
-];
+import { isReservedShortLinkSlug } from "@/lib/shortlinks/slug";
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -53,7 +31,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // Logika rewrite untuk shortlink
-  if (pathname !== "/" && slug && !RESERVED.includes(slug)) {
+  if (pathname !== "/" && slug && !isReservedShortLinkSlug(slug)) {
     return NextResponse.rewrite(
       new URL(`/api/redirect${pathname}`, request.url),
     );


### PR DESCRIPTION
## Summary
- preserve custom short-link casing instead of forcing lowercase
- keep reserved short-link routes blocked with a shared case-insensitive helper
- update short-link validation copy and make the login footer year dynamic

## Testing
- bun -e "import { normalizeShortLinkSlug, validateShortLinkSlug, isReservedShortLinkSlug } from "./lib/shortlinks/slug.js"; const samples = ["Andovi", "  https://8eh.link/Andovi  ", "Login", "andovi_test"]; for (const sample of samples) { const normalized = normalizeShortLinkSlug(sample); console.log(JSON.stringify({ sample, normalized, valid: validateShortLinkSlug(normalized), reserved: isReservedShortLinkSlug(normalized) })); }"